### PR TITLE
fix submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/jrl-umi3218/jrl-cmakemodules.git
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git
 [submodule ".travis"]
 	path = .travis
 	url = git://github.com/jrl-umi3218/jrl-travis


### PR DESCRIPTION
ref. https://github.com/humanoid-path-planner/hpp-core/issues/256.

If someone prefer using another url scheme, git can globally be configured with eg.:
```
git config --global url."git@github.com:".insteadOf https://github.com/
```